### PR TITLE
Libs: LogHelpers: rework AP_CUSTOM_FIRMWARE_STRING handling slightly

### DIFF
--- a/Libraries/LogHelpers.js
+++ b/Libraries/LogHelpers.js
@@ -38,20 +38,19 @@ function get_version_and_board(log) {
         if ("FV" in VER) {
             filter_version = VER.FV[0]
         }
+
+        if ((build_names[build_type] != null) && !fw_string.startsWith(build_names[build_type])) {
+            // If the log is from OEM-customized firmware with an
+            // AP_CUSTOM_FIRMWARE_STRING, append the base firmware info.
+            // This also means it will match how it appears in the MSGs,
+            // so os_string and fight_controller will not be returned undefined.
+            const { Maj = ['?'], Min = ['?'], Pat = ['?'] } = VER
+            fw_string += ` [${build_names[build_type]} V${Maj[0]}.${Min[0]}.${Pat[0]}]`
+        }
     }
 
     if ('MSG' in log.messageTypes) {
         const MSG = log.get("MSG")
-
-        if (build_names[build_type] && !fw_string.startsWith(build_names[build_type])) {
-            // If the log is from OEM-customized firmware with an
-            // AP_CUSTOM_FIRMWARE_STRING, append the base firmware info to match
-            // how it will appear in the MSGs. Otherwise, os_string and
-            // flight_controller will be returned undefined.
-            const { Maj = [0], Min = [0], Pat = [0] } = log.get("VER")
-            fw_string += ` [${build_names[build_type]} V${Maj[0]}.${Min[0]}.${Pat[0]}]`
-        }
-
         // Look for firmware string in MSGs, this marks the start of the log start msgs
         // The subsequent messages give more info, this is a bad way of doing it
         const len = MSG.Message.length


### PR DESCRIPTION
Moves the handling up to the `VER` case. This means we don't have to parse `VER` from the log a second time. It also means that we always append the original firmware string if we have it, rather than if we have it and there are `MSG` logs. The only other change is for the default values for version, now it will be `V?.?.?` rather than `V0.0.0`.

Sorry for being so slow!